### PR TITLE
Improve autocompletion

### DIFF
--- a/Sources/Extensions/String+Extensions.swift
+++ b/Sources/Extensions/String+Extensions.swift
@@ -15,3 +15,24 @@ internal extension Character {
         return " "
     }
 }
+
+extension StringProtocol {
+    func isContainingSequencesOfWhitespaceLonger(than count: Int) -> Bool {
+        // The documentation for 'CharacterSet.whitespaces' mentions that it contains
+        // characters from the Unicode General Category Zs & CHARACTER TABULATION (U+0009)
+        //
+        // In the Regular Expression:
+        // \p{Z} -> Unicode General Category Zs
+        // \t -> CHARACTER TABULATION (U+0009)
+        //
+        // We want to match any sequence of space that is strictly longer than count.
+        if let regularExpression = try? NSRegularExpression(pattern: "[\\p{Z}\\t]{\(count + 1),}") {
+            let fullRange = NSRange(location: 0, length: self.utf16.count)
+
+            let numberOfMatches = regularExpression.numberOfMatches(in: String(self), range: fullRange)
+            return numberOfMatches > 0
+        }
+
+        return false
+    }
+}

--- a/Sources/Extensions/UITextView+Extensions.swift
+++ b/Sources/Extensions/UITextView+Extensions.swift
@@ -11,46 +11,6 @@ import UIKit
 public extension UITextView {
 
     typealias Match = (prefix: String, word: String, range: NSRange)
-    
-    func find(prefixes: Set<String>, with delimiterSet: CharacterSet) -> Match? {
-        guard prefixes.count > 0 else { return nil }
-
-        let matches = prefixes.compactMap { find(prefix: $0, with: delimiterSet) }
-        let sorted = matches.sorted { a, b in
-            return a.range.lowerBound > b.range.lowerBound
-        }
-        return sorted.first
-    }
-    
-    func find(prefix: String, with delimiterSet: CharacterSet) -> Match? {
-        guard !prefix.isEmpty else { return nil }
-        guard let caretRange = self.caretRange else { return nil }
-        guard let cursorRange = Range(caretRange, in: text) else { return nil }
-        
-        let leadingText = text[..<cursorRange.upperBound]
-        var prefixStartIndex: String.Index!
-        for (i, char) in prefix.enumerated() {
-            guard let index = leadingText.lastIndex(of: char) else { return nil }
-            if i == 0 {
-                prefixStartIndex = index
-            } else if index.utf16Offset(in: leadingText) == prefixStartIndex.utf16Offset(in: leadingText) + 1 {
-                prefixStartIndex = index
-            } else {
-                return nil
-            }
-        }
-
-        let wordRange = prefixStartIndex..<cursorRange.upperBound
-        let word = leadingText[wordRange]
-
-        guard word.rangeOfCharacter(from: delimiterSet) == nil else { return nil }
-
-        let location = wordRange.lowerBound.utf16Offset(in: leadingText)
-        let length = wordRange.upperBound.utf16Offset(in: word) - location
-        let range = NSRange(location: location, length: length)
-        
-        return (String(prefix), String(word), range)
-    }
 
     var caretRange: NSRange? {
         guard let selectedRange = self.selectedTextRange else { return nil }
@@ -59,7 +19,197 @@ public extension UITextView {
             length: offset(from: selectedRange.start, to: selectedRange.end)
         )
     }
-    
+
+    /// Returns the last substring matching the prefixes and the delimiter sets provided.
+    /// The prefix is included in the substring, but the delimiter is not.
+    ///
+    /// If there are multiple matches, only the most recent one is returned (i. e. the closest to
+    /// the position of the caret).
+    ///
+    /// The substring must:
+    /// - start with one of strings contained in `prefixes`;
+    /// - end with any of the characters contained in `CharacterSet`;
+    /// - be contained between the beginning of the document and the upper boundary of the caret.
+    ///
+    /// - Parameters:
+    ///   - prefixes: The prefixes to match against.
+    ///   - delimiterSet: A set of character delimiting the range.
+    /// - Returns: a `Match` containing the string, prefix and range if found, `nil` otherwise.
+    func find(prefixes: Set<String>, with delimiterSet: CharacterSet, maxSpaceCountAllowed: Int = 0) -> Match? {
+        find(prefixes: prefixes, globalDelimiterSet: delimiterSet, maxSpaceCountAllowed: maxSpaceCountAllowed)
+    }
+
+    /// Returns the last substring matching the prefixes and the delimiter sets provided.
+    /// The prefix is included in the substring, but the delimiter is not.
+    ///
+    /// If there are multiple matches, only the most recent one is returned (i. e. the closest to
+    /// the position of the caret). This methods accepts a dictionary of delimiter sets, so
+    /// that different sets can be used depending on the prefix.
+    ///
+    /// The substring must:
+    /// - start with one of strings contained in `prefixes`;
+    /// - end with any of the characters contained in the `CharacterSet` matching the prefix;
+    /// - be contained between the beginning of the document and the upper boundary of the caret.
+    ///
+    /// - Parameters:
+    ///   - prefixes: The prefixes to match against.
+    ///   - delimiterSets: A dictionary of character sets delimiting the range.
+    /// - Returns: a `Match` containing the string, prefix and range if found, `nil` otherwise.
+    func find(prefixes: Set<String>,
+              with delimiterSets: [String: CharacterSet],
+              maxSpaceCountAllowed: Int = 0) -> Match? {
+        find(prefixes: prefixes, delimiterSets: delimiterSets, maxSpaceCountAllowed: maxSpaceCountAllowed)
+    }
+
+    /// Returns the last substring matching the prefixes and the delimiter sets provided.
+    /// The prefix is included in the substring, but the delimiter is not.
+    ///
+    /// If there are multiple matches, only the most recent one is returned (i. e. the closest to
+    /// the position of the caret). This methods accepts a dictionary of delimiter sets, so
+    /// that different sets can be used depending on the prefix.
+    ///
+    /// The substring must:
+    /// - start with one of strings contained in `prefixes`;
+    /// - end with any of the characters contained in the `CharacterSet` matching the prefix;
+    ///   alternatively, if `delimiterSets` is `nil` or doesn't contain the current `prefix`,
+    ///   `globalDelimiterSet` is used instead;
+    /// - be contained between the beginning of the document and the upper boundary of the caret.
+    ///
+    /// - Parameters:
+    ///   - prefixes: The prefixes to match against.
+    ///   - delimiterSets: A dictionary of character sets delimiting the range.
+    ///   - globalDelimiterSet: A set of character delimiting the range, used as
+    ///                         a fallback for all prefixes if `delimiterSets` is `nil`
+    ///                         or doesn't contain a given prefix.
+    /// - Returns: a `Match` containing the string, prefix and range if found, `nil` otherwise.
+    func find(prefixes: Set<String>,
+              delimiterSets: [String: CharacterSet]? = nil,
+              globalDelimiterSet: CharacterSet? = nil,
+              maxSpaceCountAllowed: Int = 0) -> Match? {
+        guard prefixes.count > 0 else { return nil }
+
+        let matches: [Match] = prefixes.compactMap { prefix in
+            guard let delimiterSet = delimiterSets?[prefix] ?? globalDelimiterSet else { return nil }
+            return find(prefix: prefix, with: delimiterSet, maxSpaceCountAllowed: maxSpaceCountAllowed)
+        }
+        let sorted = matches.sorted { a, b in
+            return a.range.lowerBound > b.range.lowerBound
+        }
+        return sorted.first
+    }
+
+    /// Returns the last substring matching the prefix and the delimiter sets provided.
+    /// The prefix is included in the substring, but the delimiter is not.
+    ///
+    /// If there are multiple matches, only the most recent one is returned (i. e. the closest to
+    /// the position of the caret).
+    ///
+    /// The substring must:
+    /// - start with one of strings contained in `prefixes`;
+    /// - end with any of the characters contained in the `CharacterSet` matching the prefix;
+    ///   alternatively, if `delimiterSets` is `nil` or doesn't contain the current `prefix`,
+    ///   `globalDelimiterSet` is used instead;
+    /// - be contained between the beginning of the document and the upper boundary of the caret.
+    ///
+    /// - Parameters:
+    ///   - prefixes: The prefixes to match against.
+    ///   - delimiterSet: A set of character delimiting the range.
+    /// - Returns: a `Match` containing the string, prefix and range if found, `nil` otherwise.
+    func find(prefix: String, with delimiterSet: CharacterSet?, maxSpaceCountAllowed: Int = 0) -> Match? {
+        guard !prefix.isEmpty else { return nil }
+        guard let caretRange = self.caretRange else { return nil }
+        guard let cursorRange = Range(caretRange, in: text) else { return nil }
+
+        // We're only interested in the range between the beginning of the document
+        // and the upper bound of the caret range (which is the same as the caret position
+        // when it has a zero length).
+        let leadingText = text[..<cursorRange.upperBound]
+
+        // Iterating through each characters of the prefix, since it can contain
+        // multiple characters, to make sure we're matching the full prefix and not just
+        // the first character.
+        var prefixStartIndex: String.Index = leadingText.startIndex
+        var lastMatchedCharacterIndex: String.Index = leadingText.startIndex
+        for (i, char) in prefix.enumerated() {
+            guard let index = leadingText.lastIndex(of: char) else { return nil }
+            if i == 0 {
+                // When it's the first character and an index was found,
+                // we assume it's the start of the prefix.
+                prefixStartIndex = index
+                lastMatchedCharacterIndex = index
+            } else if leadingText.distance(from: lastMatchedCharacterIndex, to: index) == 1 {
+                // When it's not the first character, we check the distance from
+                // the previous matched character. If it's 1, then the two characters
+                // are adjacent and part of the same prefix. We can keep iterating.
+                lastMatchedCharacterIndex = index
+                continue
+            } else {
+                // If none of the above conditions are true, then we assume the prefix
+                // doesn't exist.
+                //
+                // Note that if we wanted to allow parts of the prefix to be present in
+                // the substring, we'd need to keep searching for a valid prefix between
+                // the beginning of the document and 'text[..<leadingText.lastIndex(of: prefix[0])]',
+                // but that's not the case at the moment.
+                return nil
+            }
+        }
+
+        // Extracting the word based on the computed indices.
+        let wordRange = prefixStartIndex..<cursorRange.upperBound
+        let word = leadingText[wordRange]
+
+        // Sometimes, you may want to allow a number of contiguous whitespace characters
+        // inside a match, while still keeping the whitespace as a delimiter.
+        guard isWordValid(word, delimiterSet: delimiterSet, maxSpaceCountAllowed: maxSpaceCountAllowed) else {
+            return nil
+        }
+
+        // Now that we have the unicode-aware indices, we can convert them to
+        // UTF-16 offsets and be certain they will point to intended characters
+        // (and not point to the middle of a cluster).
+        let location = wordRange.lowerBound.utf16Offset(in: leadingText)
+        let length = wordRange.upperBound.utf16Offset(in: leadingText) - location
+        let range = NSRange(location: location, length: length)
+        
+        return (String(prefix), String(word), range)
+    }
+
+
+    /// Returns `true` is the given `word` is a valid match, based on the number of allowed spaces and
+    /// the delimiter set.
+    ///
+    /// - Parameters:
+    ///   - word: The word to test.
+    ///   - delimiterSet: A set of delimiting characters that can't be contained in `word`.
+    ///   - maxSpaceCountAllowed: The number of contiguous spaces allowed within `word`.
+    /// - Returns: `true` if the word is valid, `false` otherwise.
+    private func isWordValid(_ word: Substring, delimiterSet: CharacterSet?, maxSpaceCountAllowed: Int) -> Bool {
+        if maxSpaceCountAllowed > 0 {
+            if word.isContainingSequencesOfWhitespaceLonger(than: maxSpaceCountAllowed) {
+                return false
+            }
+
+            // At this point, there's either no whitespace, or a number of spaces lower
+            // than `maxSpaceCountAllowed`. Both of those cases are valid, so we can
+            // safely remove the `.whitespace` set from the delimiter set and test if any
+            // delimiting characters are present in the word.
+            if var delimiterSet = delimiterSet {
+                delimiterSet.subtract(.whitespaces)
+                if word.rangeOfCharacter(from: delimiterSet) != nil {
+                    return false
+                }
+            }
+        } else {
+            // If the word contains one of the delimiting characters, then it's not an
+            // acceptable prefix. Same caveat as above, if we wanted to allow characters
+            // contained in a multi-character prefix, we'd have to check whether there
+            // are other matches earlier in the range.
+            if let delimiterSet = delimiterSet, word.rangeOfCharacter(from: delimiterSet) != nil {
+                return false
+            }
+        }
+
+        return true
+    }
 }
-
-

--- a/Sources/Extensions/UITextView+Extensions.swift
+++ b/Sources/Extensions/UITextView+Extensions.swift
@@ -42,7 +42,9 @@ public extension UITextView {
 
         let wordRange = prefixStartIndex..<cursorRange.upperBound
         let word = leadingText[wordRange]
-        
+
+        guard word.rangeOfCharacter(from: delimiterSet) == nil else { return nil }
+
         let location = wordRange.lowerBound.utf16Offset(in: leadingText)
         let length = wordRange.upperBound.utf16Offset(in: word) - location
         let range = NSRange(location: location, length: length)

--- a/Sources/Plugins/AutocompleteManager/AutocompleteManager.swift
+++ b/Sources/Plugins/AutocompleteManager/AutocompleteManager.swift
@@ -288,7 +288,9 @@ open class AutocompleteManager: NSObject, InputPlugin, UITextViewDelegate, UITab
             location: selectedLocation,
             length: 0
         )
-        
+
+        delegate?.autocompleteManager(self, didAutocomplete: session.prefix, with: session.completion)
+
         // End the session
         unregisterCurrentSession()
     }
@@ -451,6 +453,11 @@ open class AutocompleteManager: NSObject, InputPlugin, UITextViewDelegate, UITab
                     textView.attributedText = textView.attributedText.replacingCharacters(in: rangeFromDelimiter, with: nothing)
                     textView.selectedRange = NSRange(location: subrange.location + delimiterLocation, length: 0)
                 }
+
+                if let context = attributes[.autocompletedContext] as? [String: Any] {
+                    delegate?.autocompleteManager(self, didDeleteAutocompletedRangeWithContext: context)
+                }
+
                 unregisterCurrentSession()
                 return false
             }
@@ -477,6 +484,11 @@ open class AutocompleteManager: NSObject, InputPlugin, UITextViewDelegate, UITab
                     textView.selectedRange = NSRange(location: range.location + text.count, length: 0)
                     stop.pointee = true
                 }
+
+                if let context = attributes[.autocompletedContext] as? [String: Any] {
+                    delegate?.autocompleteManager(self, didDeleteAutocompletedRangeWithContext: context)
+                }
+
                 unregisterCurrentSession()
                 return false
             }

--- a/Sources/Plugins/AutocompleteManager/Protocols/AutocompleteManagerDelegate.swift
+++ b/Sources/Plugins/AutocompleteManager/Protocols/AutocompleteManagerDelegate.swift
@@ -63,6 +63,25 @@ public protocol AutocompleteManagerDelegate: AnyObject {
     ///   - text: The text to autocomplete with
     /// - Returns: If the prefix can be autocompleted. Default is TRUE
     func autocompleteManager(_ manager: AutocompleteManager, shouldComplete prefix: String, with text: String) -> Bool
+
+
+    /// Called after when a prefix was autocompleted
+    ///
+    /// - Parameters:
+    ///   - manager: The AutocompleteManager
+    ///   - prefix: The prefix character that is currently registered
+    ///   - autocompleteCompletion: The AutocompleteCompletion object provided by the data source
+    func autocompleteManager(_ manager: AutocompleteManager,
+                             didAutocomplete prefix: String,
+                             with autocompleteCompletion: AutocompleteCompletion?)
+
+    /// Called after a range of text containing a previous autocompletion has been deleted
+    ///
+    /// - Parameters:
+    ///   - manager: The AutocompleteManager
+    ///   - context: Context similar to AutocompleteCompletion.context
+    func autocompleteManager(_ manager: AutocompleteManager,
+                             didDeleteAutocompletedRangeWithContext context: [String: Any]?)
 }
 
 public extension AutocompleteManagerDelegate {


### PR DESCRIPTION
This PR does two things.

1. It allows using different character delimiter sets depending on the prefix. This useful for us, because hashtags and username dont have the same sets of characters allowed. To be able to safely delimit an autocompletion / highlight range, it's important to get those delimiters right.
2. It fixes a couple of bugs in the autocompletion logic.
    - In some cases, the range returned by `UITextView.find` would be negative because of a [typo](https://github.com/combyne/InputBarAccessoryView/pull/1/files#diff-a29e3f47a71a5e5c81b363db82d0369a199612a81d29d3e0a0c8a3292e5d2866R172).
    - Mixing collection indices and UTF-16 offsets is a bad idea, because offsets aren't unicode aware; unicode clusters contains multiple code points but are displayed as only one character. Take the flag of Germany, for instance (🇩🇪), it's a cluster of 🇩&🇪). I realise nobody would use a flag as a prefix, but clusters happen a lot in non-alphabetic languages.
    - If you look at the negative diff, you'll see that [session.spaceCounter](https://github.com/combyne/InputBarAccessoryView/pull/1/files#diff-34219a8f3fbfb0e87768915f1a3ea767d8512d75259b94d32e6076f4aaed6e3dL419) was never incremented and always set to the curent value. Thus, unless text was pasted, the space count could never reach above 1 and a `maxSpaceCountAllowed`† set to a value greater than 1 would be ignored. To solve that problem, I pushed the logic looking for spaces into the `UITextView` extension.
    - This stuff is hard, so I tried explained what everything does thoroughly. I'm sure the next dev will appreciate that, because it took me a while to wrap my head around this.
3. Two more delegate methods were needed to be able to retrieve and remove the mentions metadata from the autocompletions.

FInally, I'll create multiple PRs on the main repo, based on those changes. The autocompletion improvements will be welcome I hope.

† `maxSpaceCountAllowed` allows autocompleted tokens to contain spaces, despite whitespace being in the delimiters. For instance, with `maxSpaceCountAllowed = 1`, we can write `@BoJack Horseman`.
